### PR TITLE
aml-vnc: Fix resolution issue when used other than native

### DIFF
--- a/aml-vnc/sources/updateScreen.c
+++ b/aml-vnc/sources/updateScreen.c
@@ -21,7 +21,7 @@ Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
 
 #define OUT_T CONCAT3E(uint,OUT,_t)
 #define FUNCTION CONCAT2E(update_screen_,OUT)
-#define COMPRECT 4
+#define COMPRECT 12
 #define MIN(a,b) (((a)<(b))?(a):(b))
 #define MAX(a,b) (((a)>(b))?(a):(b))
 
@@ -39,23 +39,31 @@ void FUNCTION(void) {
 		offset = j * vncscr->width;
 		for (i = 0; i < vncscr->width; i+=COMPRECT) {
 			if (a[i + offset] != b[i + offset]) {
-				max_x=MAX(i + COMPRECT, max_x);
-				min_x=MIN(i - COMPRECT, min_x);
-				max_y=MAX(j + COMPRECT, max_y);
 				min_y=MIN(j - COMPRECT, min_y);
+				max_y=MAX(j + COMPRECT, max_y);
 				idle = 0;
 			}
 		}
 	}
 
 	if (!idle) {
-		min_x=MAX(0, min_x);
+		min_x=0;
 		min_y=MAX(0, min_y);
-		max_x=MIN(screenformat.width - 1, max_x);
+		max_x=screenformat.width - 1;
 		max_y=MIN(screenformat.height - 1, max_y);
 
-		offset = min_x + screenformat.width * min_y;
-		memcpy(a + offset, b + offset, (max_x - min_x + screenformat.width * (max_y - min_y)) * screenformat.bitsPerPixel / CHAR_BIT);
+		struct fb_var_screeninfo scrinfo; //we'll need this to detect double FB on framebuffer
+		scrinfo = FB_getscrinfo();
+
+		for (j = min_y; j <= max_y; j++) {
+			offset = j * vncscr->width;
+			for (i = 0; i < vncscr->width; i++) {
+				a[i + offset] = b[PIXEL_TO_VIRTUALPIXEL_FB(i, j)];
+			}
+		}
+
+		offset = screenformat.width * min_y;
+		memcpy(vncbuf + offset, a + offset, screenformat.width * (max_y - min_y) * screenformat.bitsPerPixel / CHAR_BIT);
 		rfbMarkRectAsModified(vncscr, min_x, min_y, max_x, max_y);
 	}
 }


### PR DESCRIPTION
This is a possible fix for the bug that appeared in the last two patches since [78f6b5c](https://github.com/kszaq/my-addons/commit/78f6b5c2b296eeedd08ab2cf3c69a76e531e77a7), which occurs at resolutions other than native.

See references here:
https://github.com/dtechsrv/LibreELEC-AML/pull/32

Some minor changes:
- I increased the difference comparison step from 4 to 12, because it is still suitable in most cases. _(Also, the number of lines of all known resolutions is divisible by 12.)_
- In case of pixel difference, regardless of the initial X-value, the drawing starts from the beginning of the examined line before the first modified line and ends at the end of the examined line after the last modified line. _(It doesn't have much significance, but I think it's easier this way, instead of starting/finishing the drawing in the middle of the line.)_